### PR TITLE
feat: export io_source::IoSource

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ pub mod event;
 
 cfg_io_source! {
     mod io_source;
+    pub use io_source::IoSource;
 }
 
 cfg_net! {


### PR DESCRIPTION
We implemented it, but never exported it.